### PR TITLE
Added an option for column titles not on first line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ typings/
 # dotenv environment variables file
 .env
 
+# vscode settings
+.vscode/

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ The workbook should contain one meta table. The meta table define the sheets to 
 and how these sheets should be exported. The format of this meta table is as
 follow:
 
-| name          | format        | key
-| ------------- | ------------- | -----
-| SheetName     | dictionary    | id
+| name          | format        | key   | headerLine
+| ------------- | ------------- | ----- | -----------
+| SheetName     | dictionary    | id    | line number
 
 
 available formats are:
@@ -92,6 +92,7 @@ available formats are:
 The `key` column is only used for `dictionary` and `mappedlist` tables, to specify which attribute
 should be used for key. If not specified, `id` is used as key name.
 Keys can be chained (colon separated) to obtain a recursively structured object.
+`headerLine` is optional, set it if your title line is not the first one (eg. `2`).
 
 ## Array and dictionary tables
 

--- a/main.js
+++ b/main.js
@@ -355,11 +355,11 @@ function convertWorkbookToJson(workbook, metaTableName) {
 
 	// iterate on all spreadsheets defined in meta
 	for (var keys = Object.keys(meta), i = 0; i < keys.length; i++) {
-		var def   = meta[i];
-		var name  = def.name;
-		var sheet = workbook.Sheets[name];
-		var range = def.headerLine ? def.headerLine - 1 : 0;
-		var data  = XLSX.utils.sheet_to_json(sheet, { raw: true, blankrows: false, range: range });
+		var def        = meta[i];
+		var name       = def.name;
+		var sheet      = workbook.Sheets[name];
+		var headerLine = def.headerLine || 1;
+		var data       = XLSX.utils.sheet_to_json(sheet, { raw: true, blankrows: false, range: headerLine - 1 });
 
 		if (data.length === 0) {
 			throw new Error('sheetId=' + name + ' does not exist or empty');

--- a/main.js
+++ b/main.js
@@ -358,7 +358,8 @@ function convertWorkbookToJson(workbook, metaTableName) {
 		var def   = meta[i];
 		var name  = def.name;
 		var sheet = workbook.Sheets[name];
-		var data  = XLSX.utils.sheet_to_json(sheet, { raw: true, blankrows: false });
+		var range = def.headerLine ? def.headerLine - 1 : 0;
+		var data  = XLSX.utils.sheet_to_json(sheet, { raw: true, blankrows: false, range: range });
 
 		if (data.length === 0) {
 			throw new Error('sheetId=' + name + ' does not exist or empty');


### PR DESCRIPTION
Added a meta option for column titles that are not on first line: `headerLine`.

Solution from this answer: https://github.com/SheetJS/sheetjs/issues/482.